### PR TITLE
limit zoom method to videoDevices

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -545,14 +545,14 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
 
     fileprivate func _zoom(_ scale: CGFloat) {
         do {
-            let captureDevice = AVCaptureDevice.devices().first as? AVCaptureDevice
-            try captureDevice?.lockForConfiguration()
+            guard let captureDevice = AVCaptureDevice.videoDevices.first else { return }
+            try captureDevice.lockForConfiguration()
 
             zoomScale = max(1.0, min(beginZoomScale * scale, maxZoomScale))
 
-            captureDevice?.videoZoomFactor = zoomScale
+            captureDevice.videoZoomFactor = zoomScale
 
-            captureDevice?.unlockForConfiguration()
+            captureDevice.unlockForConfiguration()
 
         } catch {
             print("Error locking configuration")


### PR DESCRIPTION
Zoom was using directly first capture device (that could be the microphone) to set zoom and it crashes if first device is not a video one.