### PR TITLE
New open var saveLocationOnImages

### DIFF
--- a/camera/CameraManager.swift
+++ b/camera/CameraManager.swift
@@ -62,6 +62,9 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
     /// Property to determine if manager should write the resources to the phone library. Default value is true.
     open var writeFilesToPhoneLibrary = true
 
+    // Allow to save location on images when saving to library. Default value is true.
+    open var saveLocationOnImages = true
+    
     /// Property to determine if manager should follow device orientation. Default value is true.
     open var shouldRespondToOrientationChanges = true {
         didSet {
@@ -158,7 +161,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
 
     // MARK: - Private properties
     
-    fileprivate var locationManager = CameraLocationManager()
+    fileprivate var locationManager: CameraLocationManager?
 
     fileprivate weak var embeddingView: UIView?
     fileprivate var videoCompletion: ((_ videoURL: URL?, _ error: NSError?) -> Void)?
@@ -324,6 +327,11 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
      :param: imageCompletion Completion block containing the captured UIImage
      */
     open func capturePictureWithCompletion(_ imageCompletion: @escaping (UIImage?, NSError?) -> Void) {
+        
+        if writeFilesToPhoneLibrary && saveLocationOnImages && locationManager == nil {
+            locationManager = CameraLocationManager()
+        }
+        
         self.capturePictureDataWithCompletion { data, error in
 
             guard error == nil, let imageData = data else {
@@ -345,7 +353,7 @@ open class CameraManager: NSObject, AVCaptureFileOutputRecordingDelegate, UIGest
                         let request = PHAssetChangeRequest.creationRequestForAsset(from: flippedImage)
                         request.creationDate = Date()
                         
-                        if let location = self.locationManager.latestLocation {
+                        if let location = self.locationManager?.latestLocation {
                             request.location = location
                         }
                     }, completionHandler: { success, error in


### PR DESCRIPTION
Camera manager always try to get the location to save the location image  (therefore ask for permission if needed). 
However we do not need to save the image location. We have create a new open variable where the user of CameraManager can decide if location needs to be saved or not. 

